### PR TITLE
#162984348 Show top questions feed to users based on meetups they have signed up for.

### DIFF
--- a/UI/css/comment.css
+++ b/UI/css/comment.css
@@ -83,7 +83,7 @@ header, footer{
         visibility: hidden;
     } 
     
-} */
+}
 /* Body of Page */
 main{ 
 	display: flex;

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -270,9 +270,9 @@ img{
 
 .question{
 	border-bottom: 1px solid #bdc3c7;
-	padding: auto 20px 10px 20px;
 	margin: 10px auto;
 	width: 94%;
+	clear: left;
 }
 .quest_for_comment{
     font-size: 25px;
@@ -303,3 +303,24 @@ section, .tags{
 	justify-content: space-between;
 }
 
+/* Upcoming Meetups */
+#one, #two, #three{
+	width: 30%;
+	float: left;
+	margin: 1.66%;
+}
+#one{
+	background-color: blue;
+	text-align: center;
+	font-size: 1.5rem;
+}
+#two{
+	background-color: red;
+	text-align: center;
+	font-size: 1.5rem;
+}
+#three{
+	background-color: yellow;
+	text-align: center;
+	font-size: 1.5rem;
+}

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -327,8 +327,8 @@ section, .tags{
 	background-color: #ecf0f1;
 	text-align: center;
 	font-size: 1.5rem;
-	border: 1px solid #4f5d6b;
-	border-radius: 7px;
+	border-right: 1px solid #4f5d6b;
+	/* border-radius: 7px; */
 }
 
 

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -220,7 +220,7 @@ h1{
 }
 
 .posted_questions{
-    font-size: 4.0rem;
+    font-size: 3.0rem;
 	text-align: left;
 	margin: 0 auto 5px auto; 
 	padding-left: 80px;
@@ -327,7 +327,7 @@ section, .tags{
 	background-color: #ecf0f1;
 	text-align: center;
 	font-size: 1.5rem;
-	border-right: 1px solid #4f5d6b;
+	border-right: 1px dashed #4f5d6b;
 	/* border-radius: 7px; */
 }
 

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -2,7 +2,7 @@ body{
 	display: flex;
 	margin-bottom: 0;
     flex-direction: column;
-	min-height: 100vh;
+	min-height: fit-content;
 	font-family: 'Source Sans Pro', sans-serif;
 }
 
@@ -26,6 +26,7 @@ main > *, header, footer{
 main{
     display: flex;
 	flex-basis: auto;
+	min-height: fit-content;
 }
 
 header, footer{
@@ -52,6 +53,7 @@ header, footer{
 
 @media screen and (max-width: 800px){
     main {
+		min-height: fit-content;
 		flex-direction: column;
 		flex-grow: 1;
 	}
@@ -97,7 +99,7 @@ article{
     display: inline-block;
 	flex-basis: 30%;
 	background: #ecf0f1;
-	flex-grow: 4;
+	flex-grow: 1;
 	max-height: fit-content;
 	padding-bottom: 30px;
 }
@@ -105,15 +107,18 @@ article{
 aside{
 	flex-basis: 70%;
 	background: #ecf0f1;
-    flex-grow: 4;
-    max-height: auto;
+    flex-grow: 1;
+    min-height: auto;
 }
 
-@media all and (max-width: 640px){
-	main {
+@media all and (max-width: 720px){
+
+	body, main {
+		min-height: fit-content;
 		flex-direction: column;
 		flex-grow: 1;
 	}
+
 
 	nav {
 		order: 0;
@@ -123,7 +128,13 @@ aside{
     }
     h2{
         visibility: hidden;
-    }
+	}
+	div .meet{
+		width: 45%;
+		float: left;
+		margin: 1.30%;
+	}
+
 }
 
 /*Footer Styling*/
@@ -162,7 +173,7 @@ a{
 
 @media all and (max-width: 600px){
 	main {
-        min-height: auto;
+		min-height:fit-content;
 		flex-direction: column;
 		flex-grow: 1;
 	}
@@ -314,15 +325,15 @@ section, .tags{
 }
 
 /* Upcoming Meetups */
-#meet{
+.meet{
 	width: 30%;
 	float: left;
 	margin: 1.30%;
-}
-#meet{
 	background-color: #ecf0f1;
 	text-align: center;
 	font-size: 1.5rem;
-	border: 2px solid gray;
+	border: 1px solid #4f5d6b;
 	border-radius: 7px;
 }
+
+

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -65,11 +65,14 @@ header, footer{
 		font-size: 20px;
     }
     article{
-        padding-left: 60px;
+		padding-left: 60px;
+
     }
 	div #form{
 		width: 65%;
-    }
+	}
+	
+
 }
 
 @media screen and (max-width: 550px){
@@ -83,7 +86,7 @@ header, footer{
         visibility: hidden;
     } 
     
-} */
+} 
 /* Body of Page */
 main{ 
 	display: flex;
@@ -95,6 +98,8 @@ article{
 	flex-basis: 30%;
 	background: #ecf0f1;
 	flex-grow: 4;
+	max-height: fit-content;
+	padding-bottom: 30px;
 }
 
 aside{
@@ -134,6 +139,10 @@ aside{
 
 p #copyright{	
   text-align: center;
+}
+
+.upcoming_meetups p:hover{
+	text-decoration: underline;
 }
 
 #meetup{	
@@ -254,8 +263,9 @@ img{
 	border: none;
 	color: white;
 	padding: 10px 18px;
+	margin-bottom: 20px;
 	text-align: center;
-	font-size: 14px;
+	font-size: 14px;	
 }
 
 .button:hover {
@@ -304,23 +314,15 @@ section, .tags{
 }
 
 /* Upcoming Meetups */
-#one, #two, #three{
+#meet{
 	width: 30%;
 	float: left;
-	margin: 1.66%;
+	margin: 1.30%;
 }
-#one{
-	background-color: blue;
+#meet{
+	background-color: #ecf0f1;
 	text-align: center;
 	font-size: 1.5rem;
-}
-#two{
-	background-color: red;
-	text-align: center;
-	font-size: 1.5rem;
-}
-#three{
-	background-color: yellow;
-	text-align: center;
-	font-size: 1.5rem;
+	border: 2px solid gray;
+	border-radius: 7px;
 }

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -152,6 +152,12 @@ p #copyright{
   text-align: center;
 }
 
+hr{
+	clear:left;
+	border: 0.1px solid #b5c1cc;
+	width:92%;
+}
+
 .upcoming_meetups p:hover{
 	text-decoration: underline;
 }
@@ -334,14 +340,17 @@ section, .tags{
 	background-color: #ecf0f1;
 	text-align: center;
 	font-size: 1.5rem;
-	border-right: 1px dashed #4f5d6b;
+	/* border-right: 1px dashed #4f5d6b; */
 	/* border-radius: 7px; */
 }
 
-.rating{
-	color: #2c3e50;
+#user_blocks{
+	border: 1px solid #bdcbda;
+	border-radius: 7px;
+	margin: 5px 5px;
 }
-.rating:hover{
+
+.rating{
 	color: #008CBA;
 }
 

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -232,6 +232,13 @@ h2{
 	text-align: center;
 	margin: 5px auto 5px auto; 
 }
+h5{
+	color: #4f5d6b;
+	font-size: 1.0rem;
+	text-align: left;
+	margin: 0 auto 5px auto; 
+	padding-left: 22px;
+}
 
 img{
     display: block;
@@ -329,6 +336,17 @@ section, .tags{
 	font-size: 1.5rem;
 	border-right: 1px dashed #4f5d6b;
 	/* border-radius: 7px; */
+}
+
+.rating{
+	color: #2c3e50;
+}
+.rating:hover{
+	color: #008CBA;
+}
+
+#value{
+	padding-left: 0px;
 }
 
 

--- a/UI/css/profile.css
+++ b/UI/css/profile.css
@@ -280,12 +280,7 @@ img{
 }
 
 .button:hover {
-	background-color: #008CBA; 
-	border: 2px solid white;
-	color: white;
-	padding: 10px 18px;
-	text-align: center;
-	font-size: 14px;
+	background-color: rgb(47, 94, 163);	
 }
 
 

--- a/UI/css/register.css
+++ b/UI/css/register.css
@@ -26,7 +26,9 @@ header, footer{
 }
 
 @media all and (max-width: 600px){
+	
 	main {
+		min-height: auto;
 		flex-direction: column;
 		flex-grow: 1;
 	}

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -33,6 +33,18 @@
         <aside>
                 
             <p class="quest_for_comment"><u>Upcoming Meetups</u></p>
+            <div class="upcoming_meetups">
+                <div id="one">
+                    <p id="upcoming_meetup">Python Meetup</p>
+                </div>
+                <div id="two">
+                    <p id="upcoming_meetup">Javascript Meetup</p>
+                </div>
+                <div id="three">
+                        <p id="upcoming_meetup">Kaizala Meetup</p>
+                </div>
+                
+            </div>
             
             <div class="question">
                     <!-- <h1 class="posted_questions">19</h1> -->

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -34,14 +34,22 @@
                 
             <p class="quest_for_comment"><u>Upcoming Meetups</u></p>
             <div class="upcoming_meetups">
-                <div id="one">
+                <div id="meet">
                     <p id="upcoming_meetup">Python Meetup</p>
+                    <button class="button">Check Out</button>
+                    
                 </div>
-                <div id="two">
-                    <p id="upcoming_meetup">Javascript Meetup</p>
-                </div>
-                <div id="three">
+
+                <div id="meet">
+                        <p id="upcoming_meetup">Java Meetup</p>
+                        <button class="button">Check Out</button>
+                        
+                    </div>
+
+                <div id="meet">
                         <p id="upcoming_meetup">Kaizala Meetup</p>
+                        <button class="button">Check Out</button>
+                        
                 </div>
                 
             </div>

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -35,48 +35,37 @@
         </article>
         <aside>
 
-            <p class="quest_for_comment"><u>Upcoming Meetups</u></p>
+            <div id="user_blocks">
+                <p class="quest_for_comment"><u>Your Upcoming Meetups</u></p>
 
-            <div class="upcoming_meetups">
+                <div class="upcoming_meetups">
 
-                <div class="meet">
-                    <p id="upcoming_meetup">Python Meetup</p>
-                    <button class="button">Check it Out</button>
+                    <div class="meet">
+                        <p id="upcoming_meetup">Nairobi Python Meetup</p>
+                        <button class="button">Check it Out</button>
+
+                    </div>
+
+                    <div class="meet">
+                        <p id="upcoming_meetup">Eldoret Java Meetup</p>
+                        <button class="button">Check it Out</button>
+
+                    </div>
+
+                    <div class="meet">
+                        <p id="upcoming_meetup">Nanyuki Kaizala Meetup</p>
+                        <button class="button">Check it Out</button>
+
+                    </div>
 
                 </div>
 
-                <div class="meet">
-                    <p id="upcoming_meetup">Java Meetup</p>
-                    <button class="button">Check it Out</button>
-
-                </div>
-
-                <div class="meet">
-                    <p id="upcoming_meetup">Kaizala Meetup</p>
-                    <button class="button">Check it Out</button>
-
-                </div>
-
-            </div>
-
-            <div class="question">
-
-            </div>
-
-            <p class="quest_for_comment"><i class="fa fa-question-circle"></i>Total Number of Posted Questions:</p>
-
-            <div class="question">
-                <h1 class="posted_questions">19</h1>
-            </div>
-
-            <p class="quest_for_comment"><i class="fa fa-comments-o"></i>Total Number of Comments made:</p>
-
-            <div class="question">
-                <h1 class="posted_questions">5</h1>
+                <hr>
             </div>
 
             <div>
-                <p class="quest_for_comment"><u>Top Rated Questions for your Meetup</u></p>
+                <p class="quest_for_comment"><u>Top Rated Questions for your Meetups</u></p>
+
                 <div>
                     <h5>Nairobi Python Meetup</h5>
                     <div class="question">
@@ -87,7 +76,7 @@
                                 <tr>
                                     <td><span class="rating"> <i class="fa fa-thumbs-up"></i></span></td>
                                     <td><span class="rating"></span></td>
-                                    <td><span class="rating"> <i class="fa fa-comment"></i></span></td>
+                                    <td><span class="rating"> <i class="fa fa-thumbs-down"></i></span></td>
 
                                 </tr>
                                 <tr>
@@ -114,7 +103,7 @@
                                 <tr>
                                     <td><span class="rating"> <i class="fa fa-thumbs-up"></i></span></td>
                                     <td><span class="rating"></span></td>
-                                    <td><span class="rating"> <i class="fa fa-comment"></i></span></td>
+                                    <td><span class="rating"> <i class="fa fa-thumbs-down"></i></span></td>
 
                                 </tr>
                                 <tr>
@@ -131,34 +120,53 @@
                     </div>
 
                 </div>
-            </div>
-            <div>
-                <h5>Nanyuki Kaizala Meetup</h5>
-                <div class="question">
 
-                    Where will the meetup be held?
-                    <section>
-                        <table>
-                            <tr>
-                                <td><span class="rating"> <i class="fa fa-thumbs-up"></i></span></td>
-                                <td><span class="rating"></span></td>
-                                <td><span class="rating"> <i class="fa fa-comment"></i></span></td>
+                <div>
+                    <h5>Nanyuki Kaizala Meetup</h5>
+                    <div class="question">
 
-                            </tr>
-                            <tr>
-                                <td id="value">12</td>
-                                <td></td>
-                                <td id="value">2</td>
-                            </tr>
-                        </table>
-                        <div class="tags">
-                            <span>By:</span>
-                            <span>Marx Mutuma</span>
+                        Where will the meetup be held?
+                        <section>
+                            <table>
+                                <tr>
+                                    <td><span class="rating"> <i class="fa fa-thumbs-up"></i></span></td>
+                                    <td><span class="rating"></span></td>
+                                    <td><span class="rating"> <i class="fa fa-thumbs-down"></i></span></td>
 
-                        </div>
+                                </tr>
+                                <tr>
+                                    <td id="value">12</td>
+                                    <td></td>
+                                    <td id="value">2</td>
+                                </tr>
+                            </table>
+                            <div class="tags">
+                                <span>By:</span>
+                                <span>Marx Mutuma</span>
+
+                            </div>
+                    </div>
                 </div>
             </div>
-            </div>
+
+            <div id="user_blocks">
+                <div>
+                    <p class="quest_for_comment"><i class="fa fa-question-circle"></i>Total Number of Posted Questions:</p>
+
+                    <div class="question">
+                        <h1 class="posted_questions">19</h1>
+                    </div>
+
+
+                </div>
+
+                <div>
+                    <p class="quest_for_comment"><i class="fa fa-comments-o"></i>Total Number of Comments made:</p>
+                    <div class="question">
+                        <h1 class="posted_questions">5</h1>
+                    </div>
+
+                </div>
             </div>
 
 

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -38,25 +38,24 @@
             
                 <div class="meet">
                     <p id="upcoming_meetup">Python Meetup</p>
-                    <button class="button">Check Out</button>
+                    <button class="button">Check it Out</button>
                     
                 </div>
 
                 <div class="meet">
                         <p id="upcoming_meetup">Java Meetup</p>
-                        <button class="button">Check Out</button>
+                        <button class="button">Check it Out</button>
                         
                     </div>
 
                 <div class="meet">
                         <p id="upcoming_meetup">Kaizala Meetup</p>
-                        <button class="button">Check Out</button>
+                        <button class="button">Check it Out</button>
                         
                 </div>
 
-               
             </div>
-            
+                        
             <div class="question">
                     <!-- <h1 class="posted_questions">19</h1> -->
             </div>

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -33,7 +33,9 @@
         <aside>
                 
             <p class="quest_for_comment"><u>Upcoming Meetups</u></p>
+            
             <div class="upcoming_meetups">
+            
                 <div class="meet">
                     <p id="upcoming_meetup">Python Meetup</p>
                     <button class="button">Check Out</button>
@@ -52,24 +54,7 @@
                         
                 </div>
 
-                <div class="meet">
-                        <p id="upcoming_meetup">Python Meetup</p>
-                        <button class="button">Check Out</button>
-                        
-                    </div>
-    
-                    <div class="meet">
-                            <p id="upcoming_meetup">Java Meetup</p>
-                            <button class="button">Check Out</button>
-                            
-                        </div>
-    
-                    <div class="meet">
-                            <p id="upcoming_meetup">Kaizala Meetup</p>
-                            <button class="button">Check Out</button>
-                            
-                    </div>
-                
+               
             </div>
             
             <div class="question">

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -34,23 +34,41 @@
                 
             <p class="quest_for_comment"><u>Upcoming Meetups</u></p>
             <div class="upcoming_meetups">
-                <div id="meet">
+                <div class="meet">
                     <p id="upcoming_meetup">Python Meetup</p>
                     <button class="button">Check Out</button>
                     
                 </div>
 
-                <div id="meet">
+                <div class="meet">
                         <p id="upcoming_meetup">Java Meetup</p>
                         <button class="button">Check Out</button>
                         
                     </div>
 
-                <div id="meet">
+                <div class="meet">
                         <p id="upcoming_meetup">Kaizala Meetup</p>
                         <button class="button">Check Out</button>
                         
                 </div>
+
+                <div class="meet">
+                        <p id="upcoming_meetup">Python Meetup</p>
+                        <button class="button">Check Out</button>
+                        
+                    </div>
+    
+                    <div class="meet">
+                            <p id="upcoming_meetup">Java Meetup</p>
+                            <button class="button">Check Out</button>
+                            
+                        </div>
+    
+                    <div class="meet">
+                            <p id="upcoming_meetup">Kaizala Meetup</p>
+                            <button class="button">Check Out</button>
+                            
+                    </div>
                 
             </div>
             

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -1,17 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <title>Questions Page</title>
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
-	<link rel="stylesheet" type="text/css" href="css/profile.css">
-	<link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="css/profile.css">
+    <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
+        integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 </head>
+
 <body>
     <header>
         <label class="siteName">
             <a href="">Questioner</a>
         </label>
-        
+
         <nav class="headerNav">
             <a href=""><i class="fa fa-book"></i>Dashboard</a>
             <a href="login.html"><i class="fa fa-sign-in"></i>Logout</a>
@@ -20,67 +23,154 @@
 
     <main>
         <article>
-            
+
             <img src="assets/user1.jpg">
-       
+
             <p id="meetup">Michael N. Mbugua</p>
             <p id="meetup">Admin</p>
-            
+
             <p id="meetup"><u>Email: michaelngigi76@gmail.com</u></p>
-            
-            
-            </article>
+
+
+        </article>
         <aside>
-                
+
             <p class="quest_for_comment"><u>Upcoming Meetups</u></p>
-            
+
             <div class="upcoming_meetups">
-            
+
                 <div class="meet">
                     <p id="upcoming_meetup">Python Meetup</p>
                     <button class="button">Check it Out</button>
-                    
+
                 </div>
 
                 <div class="meet">
-                        <p id="upcoming_meetup">Java Meetup</p>
-                        <button class="button">Check it Out</button>
-                        
-                    </div>
+                    <p id="upcoming_meetup">Java Meetup</p>
+                    <button class="button">Check it Out</button>
+
+                </div>
 
                 <div class="meet">
-                        <p id="upcoming_meetup">Kaizala Meetup</p>
-                        <button class="button">Check it Out</button>
-                        
+                    <p id="upcoming_meetup">Kaizala Meetup</p>
+                    <button class="button">Check it Out</button>
+
                 </div>
 
             </div>
-                        
+
             <div class="question">
-                    <!-- <h1 class="posted_questions">19</h1> -->
+
             </div>
 
             <p class="quest_for_comment"><i class="fa fa-question-circle"></i>Total Number of Posted Questions:</p>
-            
-                <div class="question">
-                        <h1 class="posted_questions">19</h1>
-                </div>
 
-                <p class="quest_for_comment"><i class="fa fa-comments-o"></i>Total Number of Comments made:</p>
-            
-                <div class="question">
-                        <h1 class="posted_questions">5</h1>
+            <div class="question">
+                <h1 class="posted_questions">19</h1>
+            </div>
+
+            <p class="quest_for_comment"><i class="fa fa-comments-o"></i>Total Number of Comments made:</p>
+
+            <div class="question">
+                <h1 class="posted_questions">5</h1>
+            </div>
+
+            <div>
+                <p class="quest_for_comment"><u>Top Rated Questions for your Meetup</u></p>
+                <div>
+                    <h5>Nairobi Python Meetup</h5>
+                    <div class="question">
+
+                        Where will the meetup be held?
+                        <section>
+                            <table>
+                                <tr>
+                                    <td><span class="rating"> <i class="fa fa-thumbs-up"></i></span></td>
+                                    <td><span class="rating"></span></td>
+                                    <td><span class="rating"> <i class="fa fa-comment"></i></span></td>
+
+                                </tr>
+                                <tr>
+                                    <td id="value">12</td>
+                                    <td></td>
+                                    <td id="value">2</td>
+                                </tr>
+                            </table>
+                            <div class="tags">
+                                <span>By:</span>
+                                <span>Marx Mutuma</span>
+
+                            </div>
+                    </div>
+
                 </div>
-                
+                <div>
+                    <h5>Eldoret Javascript Meetup</h5>
+                    <div class="question">
+
+                        Who is the guest speaker at that meetup?
+                        <section>
+                            <table>
+                                <tr>
+                                    <td><span class="rating"> <i class="fa fa-thumbs-up"></i></span></td>
+                                    <td><span class="rating"></span></td>
+                                    <td><span class="rating"> <i class="fa fa-comment"></i></span></td>
+
+                                </tr>
+                                <tr>
+                                    <td id="value">12</td>
+                                    <td></td>
+                                    <td id="value">2</td>
+                                </tr>
+                            </table>
+                            <div class="tags">
+                                <span>By:</span>
+                                <span>Sam Smith</span>
+
+                            </div>
+                    </div>
+
+                </div>
+            </div>
+            <div>
+                <h5>Nanyuki Kaizala Meetup</h5>
+                <div class="question">
+
+                    Where will the meetup be held?
+                    <section>
+                        <table>
+                            <tr>
+                                <td><span class="rating"> <i class="fa fa-thumbs-up"></i></span></td>
+                                <td><span class="rating"></span></td>
+                                <td><span class="rating"> <i class="fa fa-comment"></i></span></td>
+
+                            </tr>
+                            <tr>
+                                <td id="value">12</td>
+                                <td></td>
+                                <td id="value">2</td>
+                            </tr>
+                        </table>
+                        <div class="tags">
+                            <span>By:</span>
+                            <span>Marx Mutuma</span>
+
+                        </div>
+                </div>
+            </div>
+            </div>
+            </div>
+
 
         </aside>
     </main>
 
     <footer class="footer-dark">
-            <p id="copyright">Questioner. © 2019. All Rights Reserved</p>
+        <p id="copyright">Questioner. © 2019. All Rights Reserved</p>
     </footer>
 
 </body>
+
 </html>
 
 ￼

--- a/UI/profile.html
+++ b/UI/profile.html
@@ -32,7 +32,13 @@
             </article>
         <aside>
                 
-                <p class="quest_for_comment"><i class="fa fa-question-circle"></i>Total Number of Posted Questions:</p>
+            <p class="quest_for_comment"><u>Upcoming Meetups</u></p>
+            
+            <div class="question">
+                    <!-- <h1 class="posted_questions">19</h1> -->
+            </div>
+
+            <p class="quest_for_comment"><i class="fa fa-question-circle"></i>Total Number of Posted Questions:</p>
             
                 <div class="question">
                         <h1 class="posted_questions">19</h1>


### PR DESCRIPTION
## What does this PR do?
This pull request creates a profile page on the Questioner Platform showing a top questions feed for any upcoming meetup(s) that they are scheduled to attend.

## Description of tasks to be completed
**The following are the tasks to be completed**

- Write html for profile.html page
- Organize the meetups being attended, the top questions, total number of posted questions and comments.
- Create buttons on all the upcoming meetups to redirect the user to the actual meetup page.

## How should you manually test this?
- Clone this repository on your local machine.
- cd UI/
- Open the profile.html file on any browser. 

## Pivotal tracker stories associated with this PR:
#162984348
![top feed](https://user-images.githubusercontent.com/19667042/50756936-d2920c00-126e-11e9-9829-302c7852de33.png)


## Screenshots