### PR TITLE
[bug #163471749] Change how the Admin is validated. Stop checking on username

### DIFF
--- a/app/api/v2/models/user_models.py
+++ b/app/api/v2/models/user_models.py
@@ -14,11 +14,11 @@ class UserModels:
     def add_user(self, firstname, lastname, othername, email, phoneNumber, username, password):
         """Adding New Users"""
 
-        payload = {
-            "Username": username,
-            "email": email,
-            "PhoneNumber": phoneNumber
-        }
+        # payload = {
+        #     "Username": username,
+        #     "email": email,
+        #     "PhoneNumber": phoneNumber
+        # }
 
         encrypted_password = generate_password_hash(password)
 
@@ -73,7 +73,7 @@ class UserModels:
             """Get password from database"""
             pass_in_db = data[9]
             if check_password_hash(pass_in_db, password):
-            # if pass_in_db == password:
+            
                 return data
             else:
                 return None
@@ -98,12 +98,12 @@ class UserModels:
         self.cur.execute(
             "SELECT * FROM users WHERE username= '{}';".format(username))
 
-        username_data = self.cur.fetchone()
+        username_rank = self.cur.fetchone()
 
-        if username_data:
-            return username_data[6]
+        if username_rank:
+            return username_rank[8]
         else:
-            return None
+            return False
 
     def get_all_users(self):
         """Return all users in the database"""

--- a/app/api/v2/views/meetup_views.py
+++ b/app/api/v2/views/meetup_views.py
@@ -148,9 +148,9 @@ def delete_meetup(meetupId):
 
     username = get_jwt_identity()
         
-    user = users.get_user(username)
+    user_rank = users.get_user(username)
     
-    if user != "admin":
+    if not user_rank:
         abort(make_response(jsonify({
                 'status': 400,
                 'Error': 'You have to be an Admin to DELETE a meetup'

--- a/app/api/v2/views/meetup_views.py
+++ b/app/api/v2/views/meetup_views.py
@@ -23,9 +23,9 @@ def create_meetup():
 
     username = get_jwt_identity()
         
-    user = users.get_user(username)
+    user_rank = users.get_user(username)
     
-    if user != "admin":
+    if not user_rank:
         abort(make_response(jsonify({
                 'status': 400,
                 'Error': 'You have to be an Admin to post a meetup'

--- a/app/api/v2/views/user_views.py
+++ b/app/api/v2/views/user_views.py
@@ -100,8 +100,7 @@ def login():
 
             elif passWrd:
 
-                # token = jwt.encode({'username': username,
-                #                     'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=30)}, app.config['SECRET_KEY'])    
+   
                 token = create_access_token(identity=username)
 
                 return make_response(jsonify({

--- a/instance/db_con.py
+++ b/instance/db_con.py
@@ -100,9 +100,9 @@ def destroy_tables():
     """Method to delete tables"""
     con = con_return()
     cur = con.cursor()
-    tables = ['users', 'meetups', 'questions', 'comments', 'rsvp']
+    tables = ['meetups', 'questions', 'comments', 'rsvp']
     for table in tables:
         cur.execute("DELETE FROM {};".format(table))
-
+    cur.execute("DELETE FROM users where username != 'admin';")
     con.commit()
 

--- a/tests/v2/test_meetup_views.py
+++ b/tests/v2/test_meetup_views.py
@@ -149,13 +149,8 @@ class TestMeetupEndPoints(unittest.TestCase):
                             headers={'Content-Type': 'application/json' , 'Authorization': 'Bearer {}'.format(token)})
 
         data = res.get_json()
-        print("********************************")
-        print(data)
-        print("********************************")
 
         self.assertEqual(res.status_code, 200)
-
-        
 
 
     def tearDown(self):

--- a/tests/v2/test_meetup_views.py
+++ b/tests/v2/test_meetup_views.py
@@ -138,9 +138,9 @@ class TestMeetupEndPoints(unittest.TestCase):
 
         res = self.client.post('api/v2/meetups',json=meetup,
                         headers={'Content-Type': 'application/json' , 'Authorization': 'Bearer {}'.format(token)})
+        
        
         data = res.get_json()
-
 
         meetupId = data['data']['meetupId']
         url = 'api/v2/meetups/{}'.format(meetupId)
@@ -148,9 +148,11 @@ class TestMeetupEndPoints(unittest.TestCase):
         res = self.client.delete(url,
                             headers={'Content-Type': 'application/json' , 'Authorization': 'Bearer {}'.format(token)})
 
-        print(res)
         data = res.get_json()
-    
+        print("********************************")
+        print(data)
+        print("********************************")
+
         self.assertEqual(res.status_code, 200)
 
         


### PR DESCRIPTION
## What does this PR do?
This pull request changes how the admin is validated before he can post a meetup 

## Description of tasks to be completed?
Implement a check for a users status in the isAdmin field. Only users with isAdmin of True can add or delete meetups

Use Postman to test for full functionality

## How should you manually test this?
### Step 1

Navigate to your working directory, create and activate virtual environment

$ virtualenv venv

$ source venv/bin/activate

Clone the repository

$ git clone https://github.com/colMike/Questioner_App.git

Install project dependencies

pip install -r requirements.txt

### Step 2

## Running the application
$ flask run

## Testing
$ pytest app/api/tests/v1

 Postman can also be used to test the route.

## Prerequisites
Pytest, Postman, Git, Virtualenv

## What are the relevant PT stories?
A user should be able to create an account #163471749 